### PR TITLE
Enable backup Unisphere

### DIFF
--- a/cmd/metrics-powermax/main.go
+++ b/cmd/metrics-powermax/main.go
@@ -173,17 +173,14 @@ func updatePowerMaxArrays(ctx context.Context, powerMaxSvc *service.PowerMaxServ
 	if err != nil {
 		logger.WithError(err).Fatal("initialize powermax arrays in controller service")
 	}
-	powerMaxClients := make(map[string]types.PowerMaxClient)
-	storageArrayID := make([]k8s.StorageArrayID, len(arrays))
 
-	for arrayID, powerMaxArray := range arrays {
-		powerMaxClients[arrayID] = powerMaxArray.Client
-		logger.WithField("arrayID", arrayID).Debug("setting powermax client")
+	powerMaxClients := make(map[string][]types.PowerMaxArray)
 
-		var arrayID = k8s.StorageArrayID{
-			ID: arrayID,
+	for arrayID, powerMaxArrays := range arrays {
+		for _, array := range powerMaxArrays {
+			powerMaxClients[arrayID] = append(powerMaxClients[arrayID], array)
 		}
-		storageArrayID = append(storageArrayID, arrayID)
+		logger.WithField("arrayID", arrayID).Debug("setting powermax client")
 	}
 	powerMaxSvc.PowerMaxClients = powerMaxClients
 }

--- a/internal/service/metric/base_metrics_test.go
+++ b/internal/service/metric/base_metrics_test.go
@@ -57,12 +57,16 @@ func Test_ExportMetrics(t *testing.T) {
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(mockVolumes, nil).Times(1)
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(6)
 
-			clients := make(map[string]types.PowerMaxClient)
 			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(&volume00833, nil).Times(1)
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(&volume00834, nil).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
 
 			service := service.PowerMaxService{
 				Logger:                 logrus.New(),
@@ -80,9 +84,13 @@ func Test_ExportMetrics(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			metrics := mocks.NewMockMetricsRecorder(ctrl)
 			volFinder := mocks.NewMockVolumeFinder(ctrl)
-			clients := make(map[string]types.PowerMaxClient)
 			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
 
 			base := &metric.BaseMetrics{
 				Logger:                 logrus.New(),

--- a/internal/service/metric/capacity_metrics_test.go
+++ b/internal/service/metric/capacity_metrics_test.go
@@ -81,12 +81,16 @@ func Test_CapacityMetricsCollect(t *testing.T) {
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(mockVolumes, nil).Times(1)
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(6)
 
-			clients := make(map[string]types.PowerMaxClient)
 			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(&volume00833, nil).Times(1)
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(&volume00834, nil).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
 
 			capacityMetric := metric.CapacityMetrics{
 				BaseMetrics: &metric.BaseMetrics{
@@ -107,7 +111,7 @@ func Test_CapacityMetricsCollect(t *testing.T) {
 			err := errors.New("find no PVs, will do nothing")
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(nil, err).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
+			clients := make(map[string][]types.PowerMaxArray)
 
 			capacityMetric := metric.CapacityMetrics{
 				BaseMetrics: &metric.BaseMetrics{
@@ -127,7 +131,7 @@ func Test_CapacityMetricsCollect(t *testing.T) {
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(5)
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(nil, nil).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
+			clients := make(map[string][]types.PowerMaxArray)
 			capacityMetric := metric.CapacityMetrics{
 				BaseMetrics: &metric.BaseMetrics{
 					VolumeFinder:           volFinder,
@@ -164,12 +168,17 @@ func Test_CapacityMetricsCollect(t *testing.T) {
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(0)
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(mockVolumes, nil).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
-			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			err := errors.New("failed to get volume")
+
+			c := mocks.NewMockPowerMaxClient(ctrl)
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, err).Times(2)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
 
 			capacityMetric := metric.CapacityMetrics{
 				BaseMetrics: &metric.BaseMetrics{
@@ -190,12 +199,16 @@ func Test_CapacityMetricsCollect(t *testing.T) {
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Return(err).Times(6)
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(mockVolumes, nil).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
 			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(&volume00833, nil).Times(1)
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(&volume00834, nil).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
 
 			capacityMetric := metric.CapacityMetrics{
 				BaseMetrics: &metric.BaseMetrics{

--- a/internal/service/metric/performance_metrics_test.go
+++ b/internal/service/metric/performance_metrics_test.go
@@ -88,16 +88,21 @@ func TestPerformanceMetrics_Collect(t *testing.T) {
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(3)
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(mockVolumes, nil).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
 			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			c.EXPECT().GetArrayPerfKeys(gomock.Any()).Return(&arrayKeysResult, nil).Times(1)
 			c.EXPECT().GetStorageGroupPerfKeys(gomock.Any(), gomock.Any()).Return(&storageGroupTimeResult, nil).Times(1)
 			c.EXPECT().GetVolumesMetrics(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return(&volumePerfMetricsResult, nil).Times(1)
 			c.EXPECT().GetStorageGroupMetrics(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return(&storageGroupPerfMetricsResult, nil).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
+
 			performanceMetric := metric.PerformanceMetrics{
 				BaseMetrics: &metric.BaseMetrics{
 					VolumeFinder:           volFinder,
@@ -117,7 +122,7 @@ func TestPerformanceMetrics_Collect(t *testing.T) {
 			err := errors.New("find no PVs, will do nothing")
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(nil, err).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
+			clients := make(map[string][]types.PowerMaxArray)
 
 			performanceMetric := metric.PerformanceMetrics{
 				BaseMetrics: &metric.BaseMetrics{
@@ -137,7 +142,7 @@ func TestPerformanceMetrics_Collect(t *testing.T) {
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(2)
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(nil, nil).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
+			clients := make(map[string][]types.PowerMaxArray)
 			performanceMetric := metric.PerformanceMetrics{
 				BaseMetrics: &metric.BaseMetrics{
 					VolumeFinder:           volFinder,
@@ -174,13 +179,18 @@ func TestPerformanceMetrics_Collect(t *testing.T) {
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(0)
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(mockVolumes, nil).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
-			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			err := errors.New("failed to get perf keys")
+			c := mocks.NewMockPowerMaxClient(ctrl)
 			c.EXPECT().GetArrayPerfKeys(gomock.Any()).Return(nil, err).Times(1)
 			c.EXPECT().GetStorageGroupPerfKeys(gomock.Any(), gomock.Any()).Return(nil, err).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
+
 			performanceMetric := metric.PerformanceMetrics{
 				BaseMetrics: &metric.BaseMetrics{
 					VolumeFinder:           volFinder,
@@ -199,17 +209,23 @@ func TestPerformanceMetrics_Collect(t *testing.T) {
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(0)
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(mockVolumes, nil).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
-			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			err := errors.New("failed to get metric")
+
+			c := mocks.NewMockPowerMaxClient(ctrl)
 			c.EXPECT().GetArrayPerfKeys(gomock.Any()).Return(&arrayKeysResult, nil).Times(1)
 			c.EXPECT().GetStorageGroupPerfKeys(gomock.Any(), gomock.Any()).Return(&storageGroupTimeResult, nil).Times(1)
 			c.EXPECT().GetVolumesMetrics(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, err).Times(1)
 			c.EXPECT().GetStorageGroupMetrics(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, err).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
+
 			performanceMetric := metric.PerformanceMetrics{
 				BaseMetrics: &metric.BaseMetrics{
 					VolumeFinder:           volFinder,
@@ -229,16 +245,21 @@ func TestPerformanceMetrics_Collect(t *testing.T) {
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Return(err).Times(3)
 			volFinder.EXPECT().GetPersistentVolumes(gomock.Any()).Return(mockVolumes, nil).Times(1)
 
-			clients := make(map[string]types.PowerMaxClient)
 			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			c.EXPECT().GetArrayPerfKeys(gomock.Any()).Return(&arrayKeysResult, nil).Times(1)
 			c.EXPECT().GetStorageGroupPerfKeys(gomock.Any(), gomock.Any()).Return(&storageGroupTimeResult, nil).Times(1)
 			c.EXPECT().GetVolumesMetrics(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return(&volumePerfMetricsResult, nil).Times(1)
 			c.EXPECT().GetStorageGroupMetrics(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return(&storageGroupPerfMetricsResult, nil).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
+
 			performanceMetric := metric.PerformanceMetrics{
 				BaseMetrics: &metric.BaseMetrics{
 					VolumeFinder:           volFinder,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -34,7 +34,7 @@ type PowerMaxService struct {
 	MetricsRecorder        types.MetricsRecorder
 	MaxPowerMaxConnections int
 	Logger                 *logrus.Logger
-	PowerMaxClients        map[string]types.PowerMaxClient
+	PowerMaxClients        map[string][]types.PowerMaxArray
 	VolumeFinder           types.VolumeFinder
 	StorageClassFinder     types.StorageClassFinder
 }
@@ -45,7 +45,7 @@ func (s *PowerMaxService) GetLogger() *logrus.Logger {
 }
 
 // GetPowerMaxClients return PowerMaxClients
-func (s *PowerMaxService) GetPowerMaxClients() map[string]types.PowerMaxClient {
+func (s *PowerMaxService) GetPowerMaxClients() map[string][]types.PowerMaxArray {
 	return s.PowerMaxClients
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -58,12 +58,16 @@ func Test_ExportCapacityMetrics(t *testing.T) {
 
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(6)
 
-			clients := make(map[string]types.PowerMaxClient)
 			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), "00833").Return(&volume00833, nil).Times(1)
 			c.EXPECT().GetVolumeByID(gomock.Any(), gomock.Any(), "00834").Return(&volume00834, nil).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
 
 			service := service.PowerMaxService{
 				Logger:                 logrus.New(),
@@ -115,16 +119,21 @@ func Test_ExportPerformanceMetrics(t *testing.T) {
 
 			metrics.EXPECT().RecordNumericMetrics(gomock.Any(), gomock.Any()).Times(3)
 
-			clients := make(map[string]types.PowerMaxClient)
 			c := mocks.NewMockPowerMaxClient(ctrl)
-			clients["000197902599"] = c
-
 			c.EXPECT().GetArrayPerfKeys(gomock.Any()).Return(&arrayKeysResult, nil).Times(1)
 			c.EXPECT().GetStorageGroupPerfKeys(gomock.Any(), gomock.Any()).Return(&storageGroupTimeResult, nil).Times(1)
 			c.EXPECT().GetVolumesMetrics(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return(&volumePerfMetricsResult, nil).Times(1)
 			c.EXPECT().GetStorageGroupMetrics(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return(&storageGroupPerfMetricsResult, nil).Times(1)
+
+			clients := make(map[string][]types.PowerMaxArray)
+			array := types.PowerMaxArray{
+				Client:   c,
+				IsActive: true,
+			}
+			clients["000197902599"] = append(clients["000197902599"], array)
+
 			service := service.PowerMaxService{
 				Logger:                 logrus.New(),
 				MetricsRecorder:        metrics,

--- a/internal/service/types/mocks/powermax_client_mocks.go
+++ b/internal/service/types/mocks/powermax_client_mocks.go
@@ -24,6 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	pmax "github.com/dell/gopowermax/v2"
 	v100 "github.com/dell/gopowermax/v2/types/v100"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -49,6 +50,20 @@ func NewMockPowerMaxClient(ctrl *gomock.Controller) *MockPowerMaxClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPowerMaxClient) EXPECT() *MockPowerMaxClientMockRecorder {
 	return m.recorder
+}
+
+// Authenticate mocks base method.
+func (m *MockPowerMaxClient) Authenticate(arg0 context.Context, arg1 *pmax.ConfigConnect) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Authenticate", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Authenticate indicates an expected call of Authenticate.
+func (mr *MockPowerMaxClientMockRecorder) Authenticate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authenticate", reflect.TypeOf((*MockPowerMaxClient)(nil).Authenticate), arg0, arg1)
 }
 
 // GetArrayPerfKeys mocks base method.

--- a/internal/service/types/mocks/service_mocks.go
+++ b/internal/service/types/mocks/service_mocks.go
@@ -119,10 +119,10 @@ func (mr *MockServiceMockRecorder) GetMetricsRecorder() *gomock.Call {
 }
 
 // GetPowerMaxClients mocks base method.
-func (m *MockService) GetPowerMaxClients() map[string]types.PowerMaxClient {
+func (m *MockService) GetPowerMaxClients() map[string][]types.PowerMaxArray {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPowerMaxClients")
-	ret0, _ := ret[0].(map[string]types.PowerMaxClient)
+	ret0, _ := ret[0].(map[string][]types.PowerMaxArray)
 	return ret0
 }
 

--- a/internal/service/types/types.go
+++ b/internal/service/types/types.go
@@ -18,9 +18,9 @@ package types
 
 import (
 	"context"
+	pmax "github.com/dell/gopowermax/v2"
 
 	"github.com/dell/csm-metrics-powermax/internal/k8s"
-	pmax "github.com/dell/gopowermax/v2"
 	types "github.com/dell/gopowermax/v2/types/v100"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
@@ -33,6 +33,7 @@ import (
 //
 //go:generate mockgen -destination=mocks/powermax_client_mocks.go -package=mocks github.com/dell/csm-metrics-powermax/internal/service/types PowerMaxClient
 type PowerMaxClient interface {
+	Authenticate(ctx context.Context, configConnect *pmax.ConfigConnect) error
 	GetStorageGroup(ctx context.Context, symID string, storageGroupID string) (*types.StorageGroup, error)
 	GetVolumeByID(ctx context.Context, symID string, volumeID string) (*types.Volume, error)
 	GetArrayPerfKeys(ctx context.Context) (*types.ArrayKeysResult, error)
@@ -77,7 +78,7 @@ type NumericMetric struct {
 //go:generate mockgen -destination=mocks/service_mocks.go -package=mocks github.com/dell/csm-metrics-powermax/internal/service/types Service
 type Service interface {
 	GetLogger() *logrus.Logger
-	GetPowerMaxClients() map[string]PowerMaxClient
+	GetPowerMaxClients() map[string][]PowerMaxArray
 	GetMetricsRecorder() MetricsRecorder
 	GetMaxPowerMaxConnections() int
 	GetVolumeFinder() VolumeFinder
@@ -111,7 +112,8 @@ type PowerMaxArray struct {
 	Password       string
 	Insecure       bool
 	IsPrimary      bool
-	Client         pmax.Pmax
+	IsActive       bool
+	Client         PowerMaxClient
 }
 
 // VolumeCapacityMetricsRecord struct for volume capacity


### PR DESCRIPTION
# Description
Previously backup U4P URL is only used when building connection, and backup U4P connection will not be saved if primary URL is working. Considering primary URL will stop working somehow, we cannot get valid connection.
So we need to save backup connection if primary U4P stop working.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/586|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make check test
```
➜  csm-metrics-powermax git:(feature-586-enable_backup_u4p_probe) make check test
./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
go test -count=1 -cover -race -timeout 30s -short `go list ./... | grep -v mock`
?       github.com/dell/csm-metrics-powermax/cmd/metrics-powermax       [no test files]
ok      github.com/dell/csm-metrics-powermax/internal/common    0.401s  coverage: 92.3% of statements
ok      github.com/dell/csm-metrics-powermax/internal/entrypoint        1.528s  coverage: 93.4% of statements
ok      github.com/dell/csm-metrics-powermax/internal/k8s       0.129s  coverage: 94.3% of statements
?       github.com/dell/csm-metrics-powermax/internal/k8sutils  [no test files]
?       github.com/dell/csm-metrics-powermax/internal/reverseproxy/common       [no test files]
ok      github.com/dell/csm-metrics-powermax/internal/reverseproxy/config       0.324s  coverage: 91.2% of statements
?       github.com/dell/csm-metrics-powermax/internal/reverseproxy/utils        [no test files]
ok      github.com/dell/csm-metrics-powermax/internal/service   0.089s  coverage: 100.0% of statements
ok      github.com/dell/csm-metrics-powermax/internal/service/metric    0.139s  coverage: 94.8% of statements
?       github.com/dell/csm-metrics-powermax/internal/service/types     [no test files]
?       github.com/dell/csm-metrics-powermax/opentelemetry/exporters    [no test files]
ok      github.com/dell/csm-metrics-powermax/utils      0.036s  coverage: 100.0% of statements
```
# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [ ] Yes
- [x] No
