### PR TITLE
Update GO to 1.20

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -58,10 +58,10 @@ jobs:
     name: Image Scanner
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19+
+      - name: Set up Go 1.20+
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.19
+          go-version: ^1.20
         id: go
       - name: Checkout the code
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/csm-metrics-powermax
 
-go 1.19
+go 1.20
 
 require (
 	github.com/dell/gopowermax/v2 v2.1.1-0.20230118020618-73d5cfc00853


### PR DESCRIPTION
# Description
Update GO to 1.20

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/658|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make check test
```
➜ make check test
./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
go test -count=1 -cover -race -timeout 30s -short `go list ./... | grep -v mock`
?       github.com/dell/csm-metrics-powermax/cmd/metrics-powermax       [no test files]
?       github.com/dell/csm-metrics-powermax/internal/k8sutils  [no test files]
?       github.com/dell/csm-metrics-powermax/internal/reverseproxy/common      [no test files]
?       github.com/dell/csm-metrics-powermax/internal/reverseproxy/utils       [no test files]
ok      github.com/dell/csm-metrics-powermax/internal/common    0.492s  coverage: 92.2% of statements
ok      github.com/dell/csm-metrics-powermax/internal/entrypoint        1.102s coverage: 91.8% of statements
ok      github.com/dell/csm-metrics-powermax/internal/k8s       0.115s  coverage: 94.3% of statements
ok      github.com/dell/csm-metrics-powermax/internal/reverseproxy/config      0.360s                                                                                                                                 c
overage: 91.2% of statements
ok      github.com/dell/csm-metrics-powermax/internal/service   0.168s  coverage: 100.0% of statements
?       github.com/dell/csm-metrics-powermax/internal/service/types     [no test files]
?       github.com/dell/csm-metrics-powermax/opentelemetry/exporters    [no test files]
ok      github.com/dell/csm-metrics-powermax/internal/service/metric    0.097s coverage: 95.0% of statements
ok      github.com/dell/csm-metrics-powermax/utils      0.023s  coverage: 100.0% of statements
```

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [ ] Yes
- [x] No
