### PR TITLE
Update gopowermax to v2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dell/csm-metrics-powermax
 go 1.20
 
 require (
-	github.com/dell/gopowermax/v2 v2.1.1-0.20230118020618-73d5cfc00853
+	github.com/dell/gopowermax/v2 v2.2.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/cucumber/messages-go/v10 v10.0.3 h1:m/9SD/K/A15WP7i1aemIv7cwvUw+viS51
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dell/gopowermax/v2 v2.1.1-0.20230118020618-73d5cfc00853 h1:ekFGFLusi+TSjQPrh27lbmsGJF//zxiwoF7yAJvcl8Y=
-github.com/dell/gopowermax/v2 v2.1.1-0.20230118020618-73d5cfc00853/go.mod h1:m5/9UOSuhs12+CnSpytJaWC53m2i4TNJ1360w7gChmc=
+github.com/dell/gopowermax/v2 v2.2.0 h1:g41Ms/GWxwZbe3IJeeVfdX1/IgnZNzpxHGi+VO+mcBA=
+github.com/dell/gopowermax/v2 v2.2.0/go.mod h1:06DoVqIp9Xt//mEqgSTzTbG2xXhWbT0mCjIjGrRRoAI=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
# Description
Update gopowermax to v2.2.0

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/583|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make check test
```
➜ make check test 
./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished  
=== Vetting...
=== Finished
=== Linting...
=== Finished        
=== Running gosec...
=== Finished
go test -count=1 -cover -race -timeout 30s -short `go list ./... | grep -v mock`
?       github.com/dell/csm-metrics-powermax/cmd/metrics-powermax       [no test files]
?       github.com/dell/csm-metrics-powermax/internal/k8sutils  [no test files]
?       github.com/dell/csm-metrics-powermax/internal/reverseproxy/common      [no test files]
ok      github.com/dell/csm-metrics-powermax/internal/common    0.422s  coverage: 92.3% of statements
ok      github.com/dell/csm-metrics-powermax/internal/entrypoint        1.509s coverage: 93.4% of statements
ok      github.com/dell/csm-metrics-powermax/internal/k8s       0.101s  coverage: 94.3% of statements       
?       github.com/dell/csm-metrics-powermax/internal/reverseproxy/utils       [no test files]
?       github.com/dell/csm-metrics-powermax/internal/service/types     [no test files]
?       github.com/dell/csm-metrics-powermax/opentelemetry/exporters    [no test files]
ok      github.com/dell/csm-metrics-powermax/internal/reverseproxy/config      0.186s                                                                                                                                     c
overage: 91.2% of statements
ok      github.com/dell/csm-metrics-powermax/internal/service   0.101s  coverage: 100.0% of statements      
ok      github.com/dell/csm-metrics-powermax/internal/service/metric    0.121s coverage: 94.8% of statements
ok      github.com/dell/csm-metrics-powermax/utils      0.026s  coverage: 100.0% of statements
```

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [ ] Yes
- [x] No
