### PR TITLE
Add nil check for claimRef to avoid segmentation violation error

### DIFF
--- a/internal/k8s/volume_finder.go
+++ b/internal/k8s/volume_finder.go
@@ -70,6 +70,13 @@ func (f VolumeFinder) GetPersistentVolumes(_ context.Context) ([]VolumeInfo, err
 			f.Logger.Debugf("The PV, %s , is not provisioned by a CSI driver\n", volume.GetName())
 			continue
 		}
+
+		// Check added to skip PV s which do not have any PVC s
+		if volume.Spec.ClaimRef == nil {
+			f.Logger.Debugf("The PV, %s , do not have a claim \n", volume.GetName())
+			continue
+		}
+
 		if contains(f.DriverNames, volume.Spec.CSI.Driver) {
 			capacity := volume.Spec.Capacity[corev1.ResourceStorage]
 			claim := volume.Spec.ClaimRef

--- a/internal/k8s/volume_finder_test.go
+++ b/internal/k8s/volume_finder_test.go
@@ -452,7 +452,7 @@ func Test_K8sPersistentVolumeFinder(t *testing.T) {
 
 			api.EXPECT().GetPersistentVolumes().Times(1).Return(volumes, nil)
 
-			finder := k8s.VolumeFinder{API: api, DriverNames: []string{"csi-isilon.dellemc.com"}, Logger: logrus.New()}
+			finder := k8s.VolumeFinder{API: api, DriverNames: []string{"csi-powermax.dellemc.com"}, Logger: logrus.New()}
 			return finder, check(hasNoError, checkExpectedOutput([]k8s.VolumeInfo{
 				{
 					Namespace:              "namespace-1",

--- a/internal/k8s/volume_finder_test.go
+++ b/internal/k8s/volume_finder_test.go
@@ -372,6 +372,107 @@ func Test_K8sPersistentVolumeFinder(t *testing.T) {
 				},
 			})), ctrl
 		},
+		"success filtering the persistent volumes which do not have claims": func(*testing.T) (k8s.VolumeFinder, []checkFn, *gomock.Controller) {
+			ctrl := gomock.NewController(t)
+			api := mocks.NewMockVolumeGetter(ctrl)
+
+			t1, err := time.Parse(time.RFC3339, "2022-06-06T20:00:00+00:00")
+			assert.Nil(t, err)
+
+			volumes := &corev1.PersistentVolumeList{
+				Items: []corev1.PersistentVolume{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "k8s-7242537ae1",
+							CreationTimestamp: metav1.Time{Time: t1},
+						},
+						Spec: corev1.PersistentVolumeSpec{
+							Capacity: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("16Gi"),
+							},
+							PersistentVolumeSource: corev1.PersistentVolumeSource{
+								CSI: &corev1.CSIPersistentVolumeSource{
+									Driver: "csi-powermax.dellemc.com",
+									VolumeAttributes: map[string]string{
+										"CapacityGB":     "12.00",
+										"CreationTime":   "20221107085924",
+										"SRP":            "SRP_1",
+										"ServiceLevel":   "Gold",
+										"StorageGroup":   "csi-BYM-Gold-SRP_1-SG",
+										"powermax/SYMID": "000197902573",
+										"storage.kubernetes.io/csiProvisionerIdentity": "1667811541157-8081-csi-powermax.dellemc.com",
+									},
+									VolumeHandle: "csi-BYM-yiming-398993ad1b-powermaxtest-000197902573-00822",
+								},
+							},
+							ClaimRef: &corev1.ObjectReference{
+								Name:      "pvc-name",
+								Namespace: "namespace-1",
+								UID:       "pvc-uid",
+							},
+							StorageClassName: "storage-class-name",
+						},
+						Status: corev1.PersistentVolumeStatus{
+							Phase: "Bound",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "k8s-7242537ae2",
+							CreationTimestamp: metav1.Time{Time: t1},
+						},
+						Spec: corev1.PersistentVolumeSpec{
+							Capacity: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("8Gi"),
+							},
+							PersistentVolumeSource: corev1.PersistentVolumeSource{
+								CSI: &corev1.CSIPersistentVolumeSource{
+									Driver: "csi-powermax.dellemc.com",
+									VolumeAttributes: map[string]string{
+										"CapacityGB":     "12.00",
+										"CreationTime":   "20221107085924",
+										"SRP":            "SRP_1",
+										"ServiceLevel":   "Gold",
+										"StorageGroup":   "csi-BYM-Gold-SRP_1-SG",
+										"powermax/SYMID": "000197902573",
+										"storage.kubernetes.io/csiProvisionerIdentity": "1667811541157-8081-csi-powermax.dellemc.com",
+									},
+									VolumeHandle: "k8s-7242537ae2=_=_=19=_=_=System=_=_=pieisi93x",
+								},
+							},
+							ClaimRef:         nil,
+							StorageClassName: "storage-class-name",
+						},
+						Status: corev1.PersistentVolumeStatus{
+							Phase: "Available",
+						},
+					},
+				},
+			}
+
+			api.EXPECT().GetPersistentVolumes().Times(1).Return(volumes, nil)
+
+			finder := k8s.VolumeFinder{API: api, DriverNames: []string{"csi-isilon.dellemc.com"}, Logger: logrus.New()}
+			return finder, check(hasNoError, checkExpectedOutput([]k8s.VolumeInfo{
+				{
+					Namespace:              "namespace-1",
+					PersistentVolumeClaim:  "pvc-uid",
+					PersistentVolumeStatus: "Bound",
+					VolumeClaimName:        "pvc-name",
+					PersistentVolume:       "k8s-7242537ae1",
+					StorageClass:           "storage-class-name",
+					Driver:                 "csi-powermax.dellemc.com",
+					ProvisionedSize:        "16Gi",
+					VolumeHandle:           "csi-BYM-yiming-398993ad1b-powermaxtest-000197902573-00822",
+					SRP:                    "SRP_1",
+					ServiceLevel:           "Gold",
+					StorageGroup:           "csi-BYM-Gold-SRP_1-SG",
+					SymID:                  "000197902573",
+					CreatedTime:            t1.String(),
+				},
+			})), ctrl
+		},
+
 		"error calling k8s": func(*testing.T) (k8s.VolumeFinder, []checkFn, *gomock.Controller) {
 			ctrl := gomock.NewController(t)
 			api := mocks.NewMockVolumeGetter(ctrl)


### PR DESCRIPTION
# Description

- Added a nil check to skip processing pvs without ClaimRef. This will prevent karavi-metrics-powermax from crashing when there are unbound pv s in clusters
- Enhanced unit tests to cover the same

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1019|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Tested the scenario using unit tests and it looks good
![image](https://github.com/dell/csm-metrics-powermax/assets/109663924/91bb3105-8a85-45f8-b34c-604b8d28cd7c)

