### PR TITLE
Support new version of reverse proxy configmap

### DIFF
--- a/internal/reverseproxy/config/config.go
+++ b/internal/reverseproxy/config/config.go
@@ -28,29 +28,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// ProxyMode represents the mode the proxy is operating in
-type ProxyMode string
-
-// Constants for the proxy configuration
-// Linked :- In linked mode, proxy simply forwards, will be obsolete
-//
-//	all the request to one of the configured
-//	primary or backup unispheres based on a fail-over
-//	mechanism which is triggered automatically, in case one
-//	of the unispheres go down.
-//
-// StandAlone :- In stand-alone mode, proxy provides multi-array
-//
-//					 support with ACL to authenticate and authorize
-//	              users based on credentials set via k8s secrets.
-//	              Each array can have a primary and a backup unisphere
-//	              which follows the same fail-over mechanism as Linked
-//	              proxy
-const (
-	Linked     = ProxyMode("Linked")
-	StandAlone = ProxyMode("StandAlone")
-)
-
 // StorageArrayConfig represents the configuration of a storage array in the config file
 type StorageArrayConfig struct {
 	StorageArrayID         string   `yaml:"storageArrayId"`
@@ -101,32 +78,19 @@ type ManagementServer struct {
 	Limits                    common.Limits
 }
 
-// LinkConfig - represents linked proxy configuration in the config file
-type LinkConfig struct {
-	Primary ManagementServerConfig `yaml:"primary" mapstructure:"primary"`
-	Backup  ManagementServerConfig `yaml:"backup,omitempty" mapstructure:"backup"`
-}
-
-// StandAloneConfig - represents stand alone proxy configuration in the config file
-type StandAloneConfig struct {
+// Config - represents proxy configuration in the config file
+type Config struct {
 	StorageArrayConfig     []StorageArrayConfig     `yaml:"storageArrays" mapstructure:"storageArrays"`
 	ManagementServerConfig []ManagementServerConfig `yaml:"managementServers" mapstructure:"managementServers"`
 }
 
 // ProxyConfigMap - represents the configuration file
 type ProxyConfigMap struct {
-	Mode             ProxyMode         `yaml:"mode,omitempty"`
-	Port             string            `yaml:"port,omitempty"`
-	LogLevel         string            `yaml:"logLevel,omitempty"`
-	LogFormat        string            `yaml:"logFormat,omitempty"`
-	LinkConfig       *LinkConfig       `yaml:"linkConfig,omitempty" mapstructure:"linkConfig"`
-	StandAloneConfig *StandAloneConfig `yaml:"standAloneConfig,omitempty" mapstructure:"standAloneConfig"`
-}
-
-// LinkedProxyConfig - represents a configuration of the Linked Proxy (formed using LinkConfig)
-type LinkedProxyConfig struct {
-	Primary *ManagementServer
-	Backup  *ManagementServer
+	Port             string  `yaml:"port,omitempty"`
+	LogLevel         string  `yaml:"logLevel,omitempty"`
+	LogFormat        string  `yaml:"logFormat,omitempty"`
+	StandAloneConfig *Config `yaml:"standAloneConfig,omitempty" mapstructure:"standAloneConfig"`
+	Config           *Config `yaml:"config,omitempty" mapstructure:"config"`
 }
 
 // StandAloneProxyConfig - represents Stand Alone Proxy Config (formed using StandAloneConfig)
@@ -202,10 +166,8 @@ func (proxy *StandAloneProxyConfig) GetStorageArray(storageArrayID string) []Sto
 
 // ProxyConfig - represents the configuration of Proxy (formed using ProxyConfigMap)
 type ProxyConfig struct {
-	Mode                  ProxyMode
-	Port                  string
-	LinkProxyConfig       *LinkedProxyConfig
-	StandAloneProxyConfig *StandAloneProxyConfig
+	Port        string
+	ProxyConfig *StandAloneProxyConfig
 }
 
 // ProxyUser - used for storing a proxy user and list of associated storage array identifiers
@@ -216,120 +178,118 @@ type ProxyUser struct {
 
 // ParseConfig - Parses a given proxy config map
 func (proxyConfig *ProxyConfig) ParseConfig(proxyConfigMap ProxyConfigMap, k8sUtils k8sutils.UtilsInterface) error {
-	proxyMode := proxyConfigMap.Mode
-	proxyConfig.Mode = proxyMode
 	proxyConfig.Port = proxyConfigMap.Port
 	fmt.Printf("ConfigMap: %v\n", proxyConfigMap)
 
-	if proxyMode == StandAlone {
-		config := proxyConfigMap.StandAloneConfig
-		if config == nil {
-			return fmt.Errorf("proxy mode is specified as StandAlone but unable to parse config")
-		}
-		var proxy StandAloneProxyConfig
-		proxy.managedArrays = make(map[string]*StorageArray)
-		proxy.managementServers = make(map[url.URL]*ManagementServer)
-		proxy.proxyCredentials = make(map[string]*ProxyUser)
-		storageArrayIdentifiers := make(map[url.URL][]string)
-		ipAddresses := make([]string, 0)
-		for _, mgmtServer := range config.ManagementServerConfig {
-			ipAddresses = append(ipAddresses, mgmtServer.URL)
-		}
-		for _, array := range config.StorageArrayConfig {
-			if array.PrimaryURL == "" {
-				return fmt.Errorf("primary URL not configured for array: %s", array.StorageArrayID)
-			}
-			if !utils.IsStringInSlice(ipAddresses, array.PrimaryURL) {
-				return fmt.Errorf("primary URL: %s for array: %s not present among management URL addresses",
-					array.PrimaryURL, array)
-			}
-			if array.BackupURL != "" {
-				if !utils.IsStringInSlice(ipAddresses, array.BackupURL) {
-					return fmt.Errorf("backup URL: %s for array: %s is not in the list of management URL addresses. Ignoring it",
-						array.BackupURL, array)
-				}
-			}
-			primaryURL, err := url.Parse(array.PrimaryURL)
-			if err != nil {
-				return err
-			}
-			backupURL := &url.URL{}
-			if array.BackupURL != "" {
-				backupURL, err = url.Parse(array.BackupURL)
-				if err != nil {
-					return err
-				}
-			}
-			proxy.managedArrays[array.StorageArrayID] = &StorageArray{
-				StorageArrayIdentifier: array.StorageArrayID,
-				PrimaryURL:             *primaryURL,
-				SecondaryURL:           *backupURL,
-			}
-			// adding Primary and Backup URl to storageArrayIdentifier, later to be used in management server
-			if _, ok := storageArrayIdentifiers[*primaryURL]; ok {
-				storageArrayIdentifiers[*primaryURL] = append(storageArrayIdentifiers[*primaryURL], array.StorageArrayID)
-			} else {
-				storageArrayIdentifiers[*primaryURL] = []string{array.StorageArrayID}
-			}
-			if _, ok := storageArrayIdentifiers[*backupURL]; ok {
-				storageArrayIdentifiers[*backupURL] = append(storageArrayIdentifiers[*backupURL], array.StorageArrayID)
-			} else {
-				storageArrayIdentifiers[*backupURL] = []string{array.StorageArrayID}
-			}
-
-			// Reading proxy credentials for the array
-			if len(array.ProxyCredentialSecrets) > 0 {
-				proxy.managedArrays[array.StorageArrayID].ProxyCredentialSecrets = make(map[string]ProxyCredentialSecret)
-				for _, secret := range array.ProxyCredentialSecrets {
-					proxyCredentials, err := k8sUtils.GetCredentialsFromSecretName(secret)
-					if err != nil {
-						return err
-					}
-					proxyCredentialSecret := &ProxyCredentialSecret{
-						Credentials:      *proxyCredentials,
-						CredentialSecret: secret,
-					}
-					proxy.managedArrays[array.StorageArrayID].ProxyCredentialSecrets[secret] = *proxyCredentialSecret
-					proxy.updateProxyCredentials(*proxyCredentials, array.StorageArrayID)
-				}
-			}
-		}
-		for _, managementServer := range config.ManagementServerConfig {
-			var arrayCredentials common.Credentials
-			if managementServer.ArrayCredentialSecret != "" {
-				credentials, err := k8sUtils.GetCredentialsFromSecretName(managementServer.ArrayCredentialSecret)
-				if err != nil {
-					return err
-				}
-				arrayCredentials = *credentials
-			}
-			mgmtURL, err := url.Parse(managementServer.URL)
-			if err != nil {
-				return err
-			}
-			var certFile string
-			if managementServer.CertSecret != "" {
-				certFile, err = k8sUtils.GetCertFileFromSecretName(managementServer.CertSecret)
-				if err != nil {
-					return err
-				}
-			}
-			proxy.managementServers[*mgmtURL] = &ManagementServer{
-				URL:                       *mgmtURL,
-				StorageArrayIdentifiers:   storageArrayIdentifiers[*mgmtURL],
-				SkipCertificateValidation: managementServer.SkipCertificateValidation,
-				CertFile:                  certFile,
-				CertSecret:                managementServer.CertSecret,
-				Credentials:               arrayCredentials,
-				CredentialSecret:          managementServer.ArrayCredentialSecret,
-				Limits:                    managementServer.Limits,
-			}
-		}
-		proxyConfig.StandAloneProxyConfig = &proxy
-	} else {
-		return fmt.Errorf("unknown proxy mode: %s specified", string(proxyMode))
+	config := proxyConfigMap.StandAloneConfig
+	if config == nil {
+		config = proxyConfigMap.Config
 	}
-	if proxyConfig.LinkProxyConfig == nil && proxyConfig.StandAloneProxyConfig == nil {
+	if config == nil {
+		return fmt.Errorf("unable to parse config")
+	}
+	var proxy StandAloneProxyConfig
+	proxy.managedArrays = make(map[string]*StorageArray)
+	proxy.managementServers = make(map[url.URL]*ManagementServer)
+	proxy.proxyCredentials = make(map[string]*ProxyUser)
+	storageArrayIdentifiers := make(map[url.URL][]string)
+	ipAddresses := make([]string, 0)
+	for _, mgmtServer := range config.ManagementServerConfig {
+		ipAddresses = append(ipAddresses, mgmtServer.URL)
+	}
+	for _, array := range config.StorageArrayConfig {
+		if array.PrimaryURL == "" {
+			return fmt.Errorf("primary URL not configured for array: %s", array.StorageArrayID)
+		}
+		if !utils.IsStringInSlice(ipAddresses, array.PrimaryURL) {
+			return fmt.Errorf("primary URL: %s for array: %s not present among management URL addresses",
+				array.PrimaryURL, array)
+		}
+		if array.BackupURL != "" {
+			if !utils.IsStringInSlice(ipAddresses, array.BackupURL) {
+				return fmt.Errorf("backup URL: %s for array: %s is not in the list of management URL addresses. Ignoring it",
+					array.BackupURL, array)
+			}
+		}
+		primaryURL, err := url.Parse(array.PrimaryURL)
+		if err != nil {
+			return err
+		}
+		backupURL := &url.URL{}
+		if array.BackupURL != "" {
+			backupURL, err = url.Parse(array.BackupURL)
+			if err != nil {
+				return err
+			}
+		}
+		proxy.managedArrays[array.StorageArrayID] = &StorageArray{
+			StorageArrayIdentifier: array.StorageArrayID,
+			PrimaryURL:             *primaryURL,
+			SecondaryURL:           *backupURL,
+		}
+		// adding Primary and Backup URl to storageArrayIdentifier, later to be used in management server
+		if _, ok := storageArrayIdentifiers[*primaryURL]; ok {
+			storageArrayIdentifiers[*primaryURL] = append(storageArrayIdentifiers[*primaryURL], array.StorageArrayID)
+		} else {
+			storageArrayIdentifiers[*primaryURL] = []string{array.StorageArrayID}
+		}
+		if _, ok := storageArrayIdentifiers[*backupURL]; ok {
+			storageArrayIdentifiers[*backupURL] = append(storageArrayIdentifiers[*backupURL], array.StorageArrayID)
+		} else {
+			storageArrayIdentifiers[*backupURL] = []string{array.StorageArrayID}
+		}
+
+		// Reading proxy credentials for the array
+		if len(array.ProxyCredentialSecrets) > 0 {
+			proxy.managedArrays[array.StorageArrayID].ProxyCredentialSecrets = make(map[string]ProxyCredentialSecret)
+			for _, secret := range array.ProxyCredentialSecrets {
+				proxyCredentials, err := k8sUtils.GetCredentialsFromSecretName(secret)
+				if err != nil {
+					return err
+				}
+				proxyCredentialSecret := &ProxyCredentialSecret{
+					Credentials:      *proxyCredentials,
+					CredentialSecret: secret,
+				}
+				proxy.managedArrays[array.StorageArrayID].ProxyCredentialSecrets[secret] = *proxyCredentialSecret
+				proxy.updateProxyCredentials(*proxyCredentials, array.StorageArrayID)
+			}
+		}
+	}
+	for _, managementServer := range config.ManagementServerConfig {
+		var arrayCredentials common.Credentials
+		if managementServer.ArrayCredentialSecret != "" {
+			credentials, err := k8sUtils.GetCredentialsFromSecretName(managementServer.ArrayCredentialSecret)
+			if err != nil {
+				return err
+			}
+			arrayCredentials = *credentials
+		}
+		mgmtURL, err := url.Parse(managementServer.URL)
+		if err != nil {
+			return err
+		}
+		var certFile string
+		if managementServer.CertSecret != "" {
+			certFile, err = k8sUtils.GetCertFileFromSecretName(managementServer.CertSecret)
+			if err != nil {
+				return err
+			}
+		}
+		proxy.managementServers[*mgmtURL] = &ManagementServer{
+			URL:                       *mgmtURL,
+			StorageArrayIdentifiers:   storageArrayIdentifiers[*mgmtURL],
+			SkipCertificateValidation: managementServer.SkipCertificateValidation,
+			CertFile:                  certFile,
+			CertSecret:                managementServer.CertSecret,
+			Credentials:               arrayCredentials,
+			CredentialSecret:          managementServer.ArrayCredentialSecret,
+			Limits:                    managementServer.Limits,
+		}
+	}
+	proxyConfig.ProxyConfig = &proxy
+
+	if proxyConfig.ProxyConfig == nil {
 		return fmt.Errorf("no configuration provided for the proxy")
 	}
 	return nil

--- a/internal/reverseproxy/config/config.go
+++ b/internal/reverseproxy/config/config.go
@@ -93,14 +93,14 @@ type ProxyConfigMap struct {
 	Config           *Config `yaml:"config,omitempty" mapstructure:"config"`
 }
 
-// StandAloneProxyConfig - represents Stand Alone Proxy Config (formed using StandAloneConfig)
-type StandAloneProxyConfig struct {
+// ReverseProxyConfig - represents reverse proxy config
+type ReverseProxyConfig struct {
 	managedArrays     map[string]*StorageArray
 	managementServers map[url.URL]*ManagementServer
 	proxyCredentials  map[string]*ProxyUser
 }
 
-func (proxy *StandAloneProxyConfig) updateProxyCredentials(creds common.Credentials, storageArrayIdentifier string) {
+func (proxy *ReverseProxyConfig) updateProxyCredentials(creds common.Credentials, storageArrayIdentifier string) {
 	if proxyUser, ok := proxy.proxyCredentials[creds.UserName]; ok {
 		if subtle.ConstantTimeCompare([]byte(creds.Password), []byte(proxyUser.ProxyCredential.Password)) == 1 {
 			// Credentials already exist in map
@@ -116,8 +116,8 @@ func (proxy *StandAloneProxyConfig) updateProxyCredentials(creds common.Credenti
 	}
 }
 
-// GetManagementServers - Returns the list of management servers present in StandAloneProxyConfig
-func (proxy *StandAloneProxyConfig) GetManagementServers() []ManagementServer {
+// GetManagementServers - Returns the list of management servers present in ReverseProxyConfig
+func (proxy *ReverseProxyConfig) GetManagementServers() []ManagementServer {
 	mgmtServers := make([]ManagementServer, 0)
 	for _, v := range proxy.managementServers {
 		mgmtServers = append(mgmtServers, *v)
@@ -126,7 +126,7 @@ func (proxy *StandAloneProxyConfig) GetManagementServers() []ManagementServer {
 }
 
 // GetManagedArraysAndServers returns a list of arrays with their corresponding management servers
-func (proxy *StandAloneProxyConfig) GetManagedArraysAndServers() map[string]StorageArrayServer {
+func (proxy *ReverseProxyConfig) GetManagedArraysAndServers() map[string]StorageArrayServer {
 	arrayServers := make(map[string]StorageArrayServer)
 	for _, server := range proxy.managementServers {
 		for _, arrayID := range server.StorageArrayIdentifiers {
@@ -150,7 +150,7 @@ func (proxy *StandAloneProxyConfig) GetManagedArraysAndServers() map[string]Stor
 }
 
 // GetStorageArray - Returns a list of storage array given a storage array id
-func (proxy *StandAloneProxyConfig) GetStorageArray(storageArrayID string) []StorageArray {
+func (proxy *ReverseProxyConfig) GetStorageArray(storageArrayID string) []StorageArray {
 	storageArrays := make([]StorageArray, 0)
 	if storageArrayID != "" {
 		if storageArray, ok := proxy.managedArrays[storageArrayID]; ok {
@@ -167,7 +167,7 @@ func (proxy *StandAloneProxyConfig) GetStorageArray(storageArrayID string) []Sto
 // ProxyConfig - represents the configuration of Proxy (formed using ProxyConfigMap)
 type ProxyConfig struct {
 	Port        string
-	ProxyConfig *StandAloneProxyConfig
+	ProxyConfig *ReverseProxyConfig
 }
 
 // ProxyUser - used for storing a proxy user and list of associated storage array identifiers
@@ -188,7 +188,7 @@ func (proxyConfig *ProxyConfig) ParseConfig(proxyConfigMap ProxyConfigMap, k8sUt
 	if config == nil {
 		return fmt.Errorf("unable to parse config")
 	}
-	var proxy StandAloneProxyConfig
+	var proxy ReverseProxyConfig
 	proxy.managedArrays = make(map[string]*StorageArray)
 	proxy.managementServers = make(map[url.URL]*ManagementServer)
 	proxy.proxyCredentials = make(map[string]*ProxyUser)

--- a/internal/reverseproxy/config/config_test.go
+++ b/internal/reverseproxy/config/config_test.go
@@ -35,6 +35,10 @@ func readConfig() (*ProxyConfigMap, error) {
 	return ReadConfig("./../" + filepath.Join(common.TestConfigDir, common.TestConfigFileName))
 }
 
+func readConfigNoModeValid() (*ProxyConfigMap, error) {
+	return ReadConfig("./../" + filepath.Join(common.TestConfigDir, "config_no_mode_valid.yaml"))
+}
+
 func readInvalidStandAloneConfig() (*ProxyConfigMap, error) {
 	return ReadConfig("./../" + filepath.Join(common.TestConfigDir, "invalid_standalone_config.yaml"))
 }
@@ -104,7 +108,6 @@ func getStandAloneProxyConfig(t *testing.T) (*ProxyConfig, error) {
 			return nil, err
 		}
 	}
-	configMap.Mode = "StandAlone"
 	config, err := NewProxyConfig(configMap, k8sUtils)
 	if err != nil {
 		t.Errorf("Failed to create new standalone proxy config. (%s)", err.Error())
@@ -118,7 +121,7 @@ func TestNewStandAloneProxyConfig(t *testing.T) {
 	if err != nil {
 		return
 	}
-	if config.StandAloneProxyConfig == nil {
+	if config.ProxyConfig == nil {
 		t.Error("Config not created properly")
 		return
 	}
@@ -129,8 +132,8 @@ func TestStandAloneProxyConfig_GetStorageArray(t *testing.T) {
 	if err != nil {
 		return
 	}
-	fmt.Printf("Storage arrays: %+v\n", config.StandAloneProxyConfig.GetStorageArray("000000000001"))
-	fmt.Printf("All Storage arrays: %+v\n", config.StandAloneProxyConfig.GetStorageArray(""))
+	fmt.Printf("Storage arrays: %+v\n", config.ProxyConfig.GetStorageArray("000000000001"))
+	fmt.Printf("All Storage arrays: %+v\n", config.ProxyConfig.GetStorageArray(""))
 }
 
 func TestGetManagedArraysAndServers(t *testing.T) {
@@ -138,11 +141,11 @@ func TestGetManagedArraysAndServers(t *testing.T) {
 	if err != nil {
 		return
 	}
-	if config.StandAloneProxyConfig == nil {
+	if config.ProxyConfig == nil {
 		t.Error("Config not created properly")
 		return
 	}
-	fmt.Printf("Management arrays and servers: %+v\n", config.StandAloneProxyConfig.GetManagedArraysAndServers())
+	fmt.Printf("Management arrays and servers: %+v\n", config.ProxyConfig.GetManagedArraysAndServers())
 }
 
 func TestGetManagementServers(t *testing.T) {
@@ -150,11 +153,11 @@ func TestGetManagementServers(t *testing.T) {
 	if err != nil {
 		return
 	}
-	if config.StandAloneProxyConfig == nil {
+	if config.ProxyConfig == nil {
 		t.Error("Config not created properly")
 		return
 	}
-	fmt.Printf("Management servers: %+v\n", config.StandAloneProxyConfig.GetManagementServers())
+	fmt.Printf("Management servers: %+v\n", config.ProxyConfig.GetManagementServers())
 }
 
 func TestGetInvalidStandAloneProxyConfig(t *testing.T) {
@@ -164,6 +167,15 @@ func TestGetInvalidStandAloneProxyConfig(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Nil(t, config)
+}
+
+func TestGetNoModeConfig(t *testing.T) {
+	configMap, err := readConfigNoModeValid()
+	if err != nil {
+		t.Errorf("%s", err.Error())
+		return
+	}
+	assert.NotNil(t, configMap)
 }
 
 func TestGetUnknownModeConfig(t *testing.T) {

--- a/internal/reverseproxy/test-config/config_no_mode_valid.yaml
+++ b/internal/reverseproxy/test-config/config_no_mode_valid.yaml
@@ -1,0 +1,47 @@
+port: 2222
+linkConfig:
+  primary:
+    url: https://primary.unisphe.re:8443
+    skipCertificateValidation: true
+    certSecret: "primary-cert"
+    limits:
+      maxActiveRead: 5
+      maxOutStandingWrite: 50
+  backup:
+    url: https://backup.unisphe.re:8443
+    skipCertificateValidation: true
+    certSecret: "backup-cert"
+config:
+  storageArrays:
+    - storageArrayId: "000000000001"
+      primaryURL: https://primary-1.unisphe.re:8443
+      backupURL: https://backup-1.unisphe.re:8443
+      proxyCredentialSecrets:
+        - proxy-secret-11
+        - proxy-secret-12
+    - storageArrayId: "000000000002"
+      primaryURL: https://primary-2.unisphe.re:8443
+      backupURL: https://backup-2.unisphe.re:8443
+      proxyCredentialSecrets:
+        - proxy-secret-21
+        - proxy-secret-22
+    - storageArrayId: "000000000003"
+      primaryURL: https://primary-1.unisphe.re:8443
+      backupURL: https://backup-1.unisphe.re:8443
+      proxyCredentialSecrets:
+        - proxy-secret-11
+        - proxy-secret-12
+  managementServers:
+    - url: https://primary-1.unisphe.re:8443
+      arrayCredentialSecret: primary-1-secret
+      certSecret: primary-cert
+      skipCertificateValidation: true
+    - url: https://backup-1.unisphe.re:8443
+      arrayCredentialSecret: backup-1-secret
+      skipCertificateValidation: false
+    - url: https://primary-2.unisphe.re:8443
+      arrayCredentialSecret: primary-2-secret
+      skipCertificateValidation: true
+    - url: https://backup-2.unisphe.re:8443
+      arrayCredentialSecret: backup-2-secret
+      skipCertificateValidation: false


### PR DESCRIPTION
# Description
Support new version of reverse proxy configmap

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1559 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have inspected the Grafana dashboards to verify the data is displayed properly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests passing
- [x] Tested in environment with latest PowerMax driver
- [x] Tested in environment with old PowerMax driver

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [x] Yes
- [ ] No


Grafana with new PowerMax driver
![image](https://github.com/user-attachments/assets/a039567a-96d9-4420-a8b4-037fc7e44fab)

Output from e2e tests with new PowerMax driver
```
=== RUN   Test_Metrics
=== RUN   Test_Metrics/PowerMax_Volume_Performance_Metrics
2025/01/09 09:33:34 TestTimeout=20
2025/01/09 09:33:34 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 09:33:34 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T09:33:34-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --longevity 20m"
2025/01/09 09:43:59 PowerMax_Volume_Performance_Metrics success after 312 attempts
time="2025-01-09T09:43:59-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T09:43:59-05:00" level=info msg="Signal SIGKILL sent to 60579. Waiting for process to exit..."
time="2025-01-09T09:43:59-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T09:43:59-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T09:43:59-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T09:44:12-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Storage_Group_Performance_Metrics
2025/01/09 09:44:12 TestTimeout=20
2025/01/09 09:44:12 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 09:44:12 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T09:44:12-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --longevity 20m"
2025/01/09 09:44:15 PowerMax_Storage_Group_Performance_Metrics success after 1 attempts
time="2025-01-09T09:44:15-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T09:44:15-05:00" level=info msg="Signal SIGKILL sent to 67170. Waiting for process to exit..."
time="2025-01-09T09:44:15-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T09:44:15-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T09:44:15-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T09:44:27-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Volume_Capacity_Metrics
2025/01/09 09:44:27 TestTimeout=20
2025/01/09 09:44:27 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 09:44:27 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T09:44:27-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 09:44:30 PowerMax_Volume_Capacity_Metrics success after 1 attempts
time="2025-01-09T09:44:30-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T09:44:30-05:00" level=info msg="Signal SIGKILL sent to 67338. Waiting for process to exit..."
time="2025-01-09T09:44:30-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T09:44:30-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T09:44:30-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T09:44:42-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Array_Capacity_Metrics
2025/01/09 09:44:42 TestTimeout=20
2025/01/09 09:44:42 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 09:44:42 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T09:44:42-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 09:44:45 PowerMax_Array_Capacity_Metrics success after 1 attempts
time="2025-01-09T09:44:45-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T09:44:45-05:00" level=info msg="Signal SIGKILL sent to 67518. Waiting for process to exit..."
time="2025-01-09T09:44:45-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T09:44:45-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T09:44:45-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T09:44:58-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Storage_Class_Capacity_Metrics
2025/01/09 09:44:58 TestTimeout=20
2025/01/09 09:44:58 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 09:44:58 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T09:44:58-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 09:45:00 PowerMax_Storage_Class_Capacity_Metrics success after 1 attempts
time="2025-01-09T09:45:00-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T09:45:00-05:00" level=info msg="Signal SIGKILL sent to 67705. Waiting for process to exit..."
time="2025-01-09T09:45:00-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T09:45:00-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T09:45:00-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T09:45:14-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Srp_Capacity_Metrics
2025/01/09 09:45:14 TestTimeout=20
2025/01/09 09:45:14 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 09:45:14 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T09:45:14-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 09:45:16 PowerMax_Srp_Capacity_Metrics success after 1 attempts
time="2025-01-09T09:45:16-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T09:45:16-05:00" level=info msg="Signal SIGKILL sent to 67885. Waiting for process to exit..."
time="2025-01-09T09:45:16-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T09:45:16-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T09:45:16-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T09:45:29-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Storage_Group_Capacity_Metrics
2025/01/09 09:45:29 TestTimeout=20
2025/01/09 09:45:29 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 09:45:29 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T09:45:29-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 09:45:31 PowerMax_Storage_Group_Capacity_Metrics success after 1 attempts
time="2025-01-09T09:45:31-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T09:45:31-05:00" level=info msg="Signal SIGKILL sent to 68062. Waiting for process to exit..."
time="2025-01-09T09:45:31-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T09:45:31-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T09:45:31-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T09:45:44-05:00" level=info msg="Process exited without error"
--- PASS: Test_Metrics (729.94s)
    --- PASS: Test_Metrics/PowerMax_Volume_Performance_Metrics (637.53s)
    --- PASS: Test_Metrics/PowerMax_Storage_Group_Performance_Metrics (15.53s)
    --- PASS: Test_Metrics/PowerMax_Volume_Capacity_Metrics (15.09s)
    --- PASS: Test_Metrics/PowerMax_Array_Capacity_Metrics (15.52s)
    --- PASS: Test_Metrics/PowerMax_Storage_Class_Capacity_Metrics (15.64s)
    --- PASS: Test_Metrics/PowerMax_Srp_Capacity_Metrics (15.49s)
    --- PASS: Test_Metrics/PowerMax_Storage_Group_Capacity_Metrics (15.12s)
PASS
ok      karavi-testing/karavi-metrics/metrics-test  731.360s
```

Grafana with old PowerMax driver
![image](https://github.com/user-attachments/assets/5dc50b40-fabf-4e36-82bb-639143649ee3)

Output from e2e tests with old PowerMax driver
```
=== RUN   Test_Metrics
=== RUN   Test_Metrics/PowerMax_Array_Capacity_Metrics
2025/01/09 10:14:37 TestTimeout=20
2025/01/09 10:14:37 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 10:14:37 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T10:14:37-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 10:14:40 PowerMax_Array_Capacity_Metrics success after 1 attempts
time="2025-01-09T10:14:40-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T10:14:40-05:00" level=info msg="Signal SIGKILL sent to 87905. Waiting for process to exit..."
time="2025-01-09T10:14:40-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T10:14:40-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T10:14:40-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T10:14:53-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Storage_Group_Capacity_Metrics
2025/01/09 10:14:53 TestTimeout=20
2025/01/09 10:14:53 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 10:14:53 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T10:14:53-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 10:14:55 PowerMax_Storage_Group_Capacity_Metrics success after 1 attempts
time="2025-01-09T10:14:55-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T10:14:55-05:00" level=info msg="Signal SIGKILL sent to 88078. Waiting for process to exit..."
time="2025-01-09T10:14:55-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T10:14:55-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T10:14:55-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T10:15:08-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Volume_Performance_Metrics
2025/01/09 10:15:08 TestTimeout=20
2025/01/09 10:15:08 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 10:15:08 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T10:15:08-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --longevity 20m"
2025/01/09 10:22:29 PowerMax_Volume_Performance_Metrics success after 220 attempts
time="2025-01-09T10:22:29-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T10:22:29-05:00" level=info msg="Signal SIGKILL sent to 88256. Waiting for process to exit..."
time="2025-01-09T10:22:29-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T10:22:29-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T10:22:29-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T10:22:42-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Storage_Group_Performance_Metrics
2025/01/09 10:22:42 TestTimeout=20
2025/01/09 10:22:42 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 10:22:42 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T10:22:42-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --longevity 20m"
2025/01/09 10:22:45 PowerMax_Storage_Group_Performance_Metrics success after 1 attempts
time="2025-01-09T10:22:45-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T10:22:45-05:00" level=info msg="Signal SIGKILL sent to 92879. Waiting for process to exit..."
time="2025-01-09T10:22:45-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T10:22:45-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T10:22:45-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T10:22:58-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Volume_Capacity_Metrics
2025/01/09 10:22:58 TestTimeout=20
2025/01/09 10:22:58 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 10:22:58 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T10:22:58-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 10:23:00 PowerMax_Volume_Capacity_Metrics success after 1 attempts
time="2025-01-09T10:23:00-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T10:23:00-05:00" level=info msg="Signal SIGKILL sent to 93070. Waiting for process to exit..."
time="2025-01-09T10:23:00-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T10:23:00-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T10:23:00-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T10:23:14-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Srp_Capacity_Metrics
2025/01/09 10:23:14 TestTimeout=20
2025/01/09 10:23:14 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 10:23:14 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T10:23:14-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 10:23:16 PowerMax_Srp_Capacity_Metrics success after 1 attempts
time="2025-01-09T10:23:16-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T10:23:16-05:00" level=info msg="Signal SIGKILL sent to 93262. Waiting for process to exit..."
time="2025-01-09T10:23:16-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T10:23:16-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T10:23:16-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T10:23:30-05:00" level=info msg="Process exited without error"
=== RUN   Test_Metrics/PowerMax_Storage_Class_Capacity_Metrics
2025/01/09 10:23:30 TestTimeout=20
2025/01/09 10:23:30 CERTCSI_LONGEVITY_TIME=20m
2025/01/09 10:23:30 VolumeCount=4, WriterCount=4, ScrapeInterval=2, TestTimeout=20, CertCsiLongevityTime=20m
time="2025-01-09T10:23:30-05:00" level=info msg="Running: /usr/local/bin/cert-csi test vio --sc powermax-iscsi-xfs --chainNumber 4 --chainLength 4 --no-metrics --no-reports --no-cleanup --longevity 20m"
2025/01/09 10:23:32 PowerMax_Storage_Class_Capacity_Metrics success after 1 attempts
time="2025-01-09T10:23:32-05:00" level=info msg="Sending signal to stop cert-csi process..."
time="2025-01-09T10:23:32-05:00" level=info msg="Signal SIGKILL sent to 93436. Waiting for process to exit..."
time="2025-01-09T10:23:32-05:00" level=info msg="Wait for cert-csi completed"
time="2025-01-09T10:23:32-05:00" level=info msg="Running: /usr/local/bin/cert-csi cleanup"
time="2025-01-09T10:23:32-05:00" level=info msg="Waiting for cert-csi command to finish"
time="2025-01-09T10:23:45-05:00" level=info msg="Process exited without error"
--- PASS: Test_Metrics (547.95s)
    --- PASS: Test_Metrics/PowerMax_Array_Capacity_Metrics (15.42s)
    --- PASS: Test_Metrics/PowerMax_Storage_Group_Capacity_Metrics (15.57s)
    --- PASS: Test_Metrics/PowerMax_Volume_Performance_Metrics (453.43s)
    --- PASS: Test_Metrics/PowerMax_Storage_Group_Performance_Metrics (16.26s)
    --- PASS: Test_Metrics/PowerMax_Volume_Capacity_Metrics (16.05s)
    --- PASS: Test_Metrics/PowerMax_Srp_Capacity_Metrics (15.67s)
    --- PASS: Test_Metrics/PowerMax_Storage_Class_Capacity_Metrics (15.54s)
PASS
ok      karavi-testing/karavi-metrics/metrics-test  549.310s
```
